### PR TITLE
RDKCOM-4941 RDKBDEV-2808 : Add pthread mutex lock

### DIFF
--- a/source/RdkVlanManager/ssp_main.c
+++ b/source/RdkVlanManager/ssp_main.c
@@ -58,6 +58,7 @@
 #include "ssp_global.h"
 #include "stdlib.h"
 #include "ccsp_dm_api.h"
+#include "vlan_apis.h"
 
 #define DEBUG_INI_NAME "/etc/debug.ini"
 
@@ -264,6 +265,7 @@ int main(int argc, char* argv[])
 
     //rdklogger init
     rdk_logger_init(DEBUG_INI_NAME);
+    VLAN_InitMutex();
 
     if ( bRunAsDaemon ) 
         daemonize();
@@ -350,6 +352,7 @@ int main(int argc, char* argv[])
 
 	ssp_cancel();
 
+    VLAN_DelMutex();
     return 0;
 }
 

--- a/source/TR-181/include/vlan_apis.h
+++ b/source/TR-181/include/vlan_apis.h
@@ -124,6 +124,8 @@ Vlan_GetStatus
 
 void * Vlan_Enable(void *Arg);
 void * Vlan_Disable(void *Arg);
+void VLAN_InitMutex();
+void VLAN_DelMutex();
 
 void get_uptime(long *uptime);
 #endif


### PR DESCRIPTION
Reason for change:
There is a possibility that when disable/enable VLANs quickly, the execution order of threads at similar times may be chaotic Test Procedure:
Not applicable
Risks: Low
Signed-off-by: Geoff Lu <geoff_lu@sdc.sercomm.com>