### PR TITLE
RDKBDEV-2848: remove dependency on dbus

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,8 +84,6 @@ dnl Checks for library functions.
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([memset strdup strerror])
 
-PKG_CHECK_MODULES([DBUS],[dbus-1 >= 1.6.18])
-
 AC_CONFIG_FILES([Makefile
 		source/Makefile
 		source/TR-181/Makefile

--- a/source/RdkVlanManager/Makefile.am
+++ b/source/RdkVlanManager/Makefile.am
@@ -47,7 +47,7 @@ VlanManager_DEPENDENCIES = \
         $(EXTRA_DEPENDENCIES) \
         ${top_builddir}/source/TR-181/middle_layer_src/libRdkVlanManager_middle_layer_src.la
 
-VlanManager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
+VlanManager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(SYSTEMD_CFLAGS)
 VlanManager_SOURCES = ssp_action.c ssp_messagebus_interface.c ssp_main.c dm_pack_datamodel.c
-VlanManager_LDFLAGS = -lccsp_common -lrdkloggers -lprivilege $(DBUS_LIBS) $(SYSTEMD_LDFLAGS) -lsecure_wrapper
+VlanManager_LDFLAGS = -lccsp_common -lrdkloggers -lprivilege $(SYSTEMD_LDFLAGS) -lsecure_wrapper
 VlanManager_LDADD = $(VlanManager_DEPENDENCIES)

--- a/source/RdkVlanManager/ssp_messagebus_interface.c
+++ b/source/RdkVlanManager/ssp_messagebus_interface.c
@@ -60,36 +60,6 @@ extern char                 g_Subsystem[32];
 extern ANSC_HANDLE          g_MessageBusHandle_Irep; 
 extern char                 g_SubSysPrefix_Irep[32];
 
-DBusHandlerResult
-CcspComp_path_message_func
-    (
-        DBusConnection  *conn,
-        DBusMessage     *message,
-        void            *user_data
-    )
-{
-    CCSP_MESSAGE_BUS_INFO *bus_info =(CCSP_MESSAGE_BUS_INFO *) user_data;
-    const char *interface = dbus_message_get_interface(message);
-    const char *method   = dbus_message_get_member(message);
-    DBusMessage *reply;
-
-    reply = dbus_message_new_method_return (message);
-    if (reply == NULL)
-    {
-        return DBUS_HANDLER_RESULT_HANDLED;
-    }
-
-    return CcspBaseIf_base_path_message_func
-               (
-                   conn,
-                   message,
-                   reply,
-                   interface,
-                   method,
-                   bus_info
-               );
-}
-
 ANSC_STATUS
 ssp_Mbi_MessageBusEngage
     (
@@ -148,23 +118,6 @@ ssp_Mbi_MessageBusEngage
     cb.busCheck               = ssp_Mbi_Buscheck;
 
     CcspBaseIf_SetCallback(bus_handle, &cb);
-
-    /* Register service callback functions */
-    returnStatus =
-        CCSP_Message_Bus_Register_Path
-            (
-                bus_handle,
-                path,
-                CcspComp_path_message_func,
-                bus_handle
-            );
-
-    if ( returnStatus != CCSP_Message_Bus_OK )
-    {
-        CcspTraceError((" !!! CCSP_Message_Bus_Register_Path ERROR returnStatus: %d\n!!!\n", returnStatus));
-
-        return returnStatus;
-    }
 
 
     /* Register event/signal */


### PR DESCRIPTION
Reason for change:
RDK Broadband messaging is moved to rbus.
So cleaning up the dbus dependency.
Test Proedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>