### PR TITLE
RDKB-58019 : Adding version log.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,11 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],
    AC_SUBST(AM_DEFAULT_VERBOSITY)])
 
 
+#Add git version
+m4_define([GITVERSION],
+  m4_esyscmd_s([git describe --tags --always --dirty 2>/dev/null || echo "undefined"])
+)
+AC_SUBST([GIT_VERSION], [GITVERSION])
 
 
 dnl **********************************

--- a/source/RdkVlanManager/Makefile.am
+++ b/source/RdkVlanManager/Makefile.am
@@ -51,3 +51,4 @@ VlanManager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
 VlanManager_SOURCES = ssp_action.c ssp_messagebus_interface.c ssp_main.c dm_pack_datamodel.c
 VlanManager_LDFLAGS = -lccsp_common -lrdkloggers -lprivilege $(DBUS_LIBS) $(SYSTEMD_LDFLAGS) -lsecure_wrapper
 VlanManager_LDADD = $(VlanManager_DEPENDENCIES)
+VlanManager_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"

--- a/source/RdkVlanManager/ssp_main.c
+++ b/source/RdkVlanManager/ssp_main.c
@@ -264,6 +264,8 @@ int main(int argc, char* argv[])
     rdk_logger_init(DEBUG_INI_NAME);
     VLAN_InitMutex();
 
+    CcspTraceInfo(("Version : %s \n",GIT_VERSION ));
+
     if ( bRunAsDaemon ) 
     {    
         daemonize();


### PR DESCRIPTION
Reason for change:  Adding version log using "git describe --tags --always --dirty" command Example :
RC2.7.0a-1-g5aa0583-dirty
Tag: RC2.7.0a (Most recent tag)
Number of Commits Ahead: -1 (1 commit after the tag) Commit Hash: g5aa0583 ( "5aa0583" Hash of the current commit) Uncommitted Changes: -dirty (Changes not yet committed)

Test Procedure:
Version log should be present.

Priority: P1
Risks: none