### PR TITLE
RDKCOM-5221 RDKBDEV-3088: remove dependency on dbus

### DIFF
--- a/source/RdkVlanManager/ssp_messagebus_interface.c
+++ b/source/RdkVlanManager/ssp_messagebus_interface.c
@@ -60,36 +60,6 @@ extern char                 g_Subsystem[32];
 extern ANSC_HANDLE          g_MessageBusHandle_Irep; 
 extern char                 g_SubSysPrefix_Irep[32];
 
-DBusHandlerResult
-CcspComp_path_message_func
-    (
-        DBusConnection  *conn,
-        DBusMessage     *message,
-        void            *user_data
-    )
-{
-    CCSP_MESSAGE_BUS_INFO *bus_info =(CCSP_MESSAGE_BUS_INFO *) user_data;
-    const char *interface = dbus_message_get_interface(message);
-    const char *method   = dbus_message_get_member(message);
-    DBusMessage *reply;
-
-    reply = dbus_message_new_method_return (message);
-    if (reply == NULL)
-    {
-        return DBUS_HANDLER_RESULT_HANDLED;
-    }
-
-    return CcspBaseIf_base_path_message_func
-               (
-                   conn,
-                   message,
-                   reply,
-                   interface,
-                   method,
-                   bus_info
-               );
-}
-
 ANSC_STATUS
 ssp_Mbi_MessageBusEngage
     (
@@ -148,24 +118,6 @@ ssp_Mbi_MessageBusEngage
     cb.busCheck               = ssp_Mbi_Buscheck;
 
     CcspBaseIf_SetCallback(bus_handle, &cb);
-
-    /* Register service callback functions */
-    returnStatus =
-        CCSP_Message_Bus_Register_Path
-            (
-                bus_handle,
-                path,
-                CcspComp_path_message_func,
-                bus_handle
-            );
-
-    if ( returnStatus != CCSP_Message_Bus_OK )
-    {
-        CcspTraceError((" !!! CCSP_Message_Bus_Register_Path ERROR returnStatus: %d\n!!!\n", returnStatus));
-
-        return returnStatus;
-    }
-
 
     /* Register event/signal */
     returnStatus = 


### PR DESCRIPTION
Reason for change:
remove dependency on dbus
Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <amccurdy@libertyglobal.com>