### PR TITLE
RDKB-58588 : [VlanManager] Fix build failure in VlanManager

### DIFF
--- a/source/RdkVlanManager/ssp_main.c
+++ b/source/RdkVlanManager/ssp_main.c
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
     CcspTraceInfo(("RDKB_SYSTEM_BOOT_UP_LOG : vlanmanager sd_notify Called\n"));
 #endif
 	
-    system("touch /tmp/vlanmanager_initialized");
+    v_secure_system("touch /tmp/vlanmanager_initialized");
 
     if ( bRunAsDaemon )
     {


### PR DESCRIPTION
Reason for change:
Changing system() with v_secure_system()

Test Procedure:
VLAN component should compile.

Risks: none
Priority: P1