### PR TITLE
RDKCOM-5242 RDKBDEV-3075 remove dependency on dbus

### DIFF
--- a/source/RdkVlanManager/ssp_main.c
+++ b/source/RdkVlanManager/ssp_main.c
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
     CcspTraceInfo(("RDKB_SYSTEM_BOOT_UP_LOG : vlanmanager sd_notify Called\n"));
 #endif
 	
-    system("touch /tmp/vlanmanager_initialized");
+    v_secure_system("touch /tmp/vlanmanager_initialized");
 
     if ( bRunAsDaemon )
     {

--- a/source/RdkVlanManager/ssp_messagebus_interface.c
+++ b/source/RdkVlanManager/ssp_messagebus_interface.c
@@ -60,35 +60,6 @@ extern char                 g_Subsystem[32];
 extern ANSC_HANDLE          g_MessageBusHandle_Irep; 
 extern char                 g_SubSysPrefix_Irep[32];
 
-DBusHandlerResult
-CcspComp_path_message_func
-    (
-        DBusConnection  *conn,
-        DBusMessage     *message,
-        void            *user_data
-    )
-{
-    CCSP_MESSAGE_BUS_INFO *bus_info =(CCSP_MESSAGE_BUS_INFO *) user_data;
-    const char *interface = dbus_message_get_interface(message);
-    const char *method   = dbus_message_get_member(message);
-    DBusMessage *reply;
-
-    reply = dbus_message_new_method_return (message);
-    if (reply == NULL)
-    {
-        return DBUS_HANDLER_RESULT_HANDLED;
-    }
-
-    return CcspBaseIf_base_path_message_func
-               (
-                   conn,
-                   message,
-                   reply,
-                   interface,
-                   method,
-                   bus_info
-               );
-}
 
 ANSC_STATUS
 ssp_Mbi_MessageBusEngage
@@ -148,23 +119,6 @@ ssp_Mbi_MessageBusEngage
     cb.busCheck               = ssp_Mbi_Buscheck;
 
     CcspBaseIf_SetCallback(bus_handle, &cb);
-
-    /* Register service callback functions */
-    returnStatus =
-        CCSP_Message_Bus_Register_Path
-            (
-                bus_handle,
-                path,
-                CcspComp_path_message_func,
-                bus_handle
-            );
-
-    if ( returnStatus != CCSP_Message_Bus_OK )
-    {
-        CcspTraceError((" !!! CCSP_Message_Bus_Register_Path ERROR returnStatus: %ld\n!!!\n", returnStatus));
-
-        return returnStatus;
-    }
 
 
     /* Register event/signal */


### PR DESCRIPTION
RDKBDEV-3075: remove dependency on dbus
Reason for change:Remove dependency on dbus
Test Procedure: Sanity.
Risks: None.
Signed-off-by:
Andre McCurdy <amccurdy@libertyglobal.com>
SukanyaIlavarasi <sukanya.i@tataelxsi.co.in>