### PR TITLE
RDKCOM-5255: RDKBDEV-3105 Valgrind- Investigate possible memory leak in RdkVlanM…

### DIFF
--- a/source/RdkVlanManager/ssp_action.c
+++ b/source/RdkVlanManager/ssp_action.c
@@ -107,6 +107,8 @@ ssp_create
 
         if ( !pSsdCcdIf )
         {
+            AnscFreeMemory( g_pComponent_COMMON_vlanmanager);
+            g_pComponent_COMMON_vlanmanager = NULL;
             return ANSC_STATUS_RESOURCES;
         }
         else
@@ -140,6 +142,10 @@ ssp_create
 
         if ( !pDslhLcbIf )
         {
+            AnscFreeMemory(pSsdCcdIf);
+            pSsdCcdIf = NULL;
+            AnscFreeMemory( g_pComponent_COMMON_vlanmanager);
+            g_pComponent_COMMON_vlanmanager = NULL;
             return ANSC_STATUS_RESOURCES;
         }
         else
@@ -160,6 +166,12 @@ ssp_create
     {
         CcspTraceError(("CANNOT Create pDslhCpeController... Exit!\n"));
 
+        AnscFreeMemory(pDslhLcbIf);
+        pDslhLcbIf = NULL;
+        AnscFreeMemory(pSsdCcdIf);
+        pSsdCcdIf = NULL;
+        AnscFreeMemory( g_pComponent_COMMON_vlanmanager);
+        g_pComponent_COMMON_vlanmanager = NULL;
         return ANSC_STATUS_RESOURCES;
     }
 

--- a/source/TR-181/middle_layer_src/ethernet_apis.c
+++ b/source/TR-181/middle_layer_src/ethernet_apis.c
@@ -790,6 +790,13 @@ ANSC_STATUS EthLink_GetMarking(char *ifname, vlan_configuration_t *pVlanCfg)
                 //allocate memory to vlan_skb_config_t, free it once used.
                 pVlanCfg->skbMarkingNumOfEntries = p_EthLink->NumberofMarkingEntries;
                 pVlanCfg->skb_config = (vlan_skb_config_t*)malloc( p_EthLink->NumberofMarkingEntries * sizeof(vlan_skb_config_t) );
+
+                if( NULL == pVlanCfg->skb_config )
+                {
+                    CcspTraceError(("%s - %d : Invalid SKB priority\n", __FUNCTION__, __LINE__));
+                    return ANSC_STATUS_FAILURE;
+                }
+
                 for(int i = 0; i < p_EthLink->NumberofMarkingEntries; i++)
                 {
                     PCOSA_DML_MARKING pDataModelMarking = (PCOSA_DML_MARKING)&(p_EthLink->pstDataModelMarking[i]);
@@ -806,6 +813,8 @@ ANSC_STATUS EthLink_GetMarking(char *ifname, vlan_configuration_t *pVlanCfg)
                     else
                     {
                         CcspTraceError(("%s-%d: pDataModelMarking Or pVlanCfg->skb_config are Null \n", __FUNCTION__, __LINE__));
+                        free(pVlanCfg->skb_config);
+                        pVlanCfg->skb_config = NULL;
                         return ANSC_STATUS_FAILURE;
                     }
                 }

--- a/source/TR-181/middle_layer_src/vlan_internal.c
+++ b/source/TR-181/middle_layer_src/vlan_internal.c
@@ -197,7 +197,12 @@ static ANSC_STATUS VlanTerminationInitialize( ANSC_HANDLE hThisObject)
         }
 
         PDML_VLAN pVlan = (PDML_VLAN)AnscAllocateMemory(sizeof(DML_VLAN)* pMyObject->ulVlantrInstanceNumber);
-        memset(pVlan, 0, sizeof(DML_VLAN));
+        if ( !pVlan )
+        {
+            CcspTraceError(("%s %d - Memory allocation Failed\n", __FUNCTION__, __LINE__));
+            return returnStatus;
+        }
+        memset(pVlan, 0, sizeof(DML_VLAN)* pMyObject->ulVlantrInstanceNumber);
 
         for(nIndex = 0; nIndex < pMyObject->ulVlantrInstanceNumber; nIndex++)
         {
@@ -313,7 +318,13 @@ static ANSC_STATUS VlanTerminationInitialize( ANSC_HANDLE hThisObject)
     pMyObject->ulVlantrInstanceNumber = vlanCount ;
 
     PDML_VLAN pVlan = (PDML_VLAN)AnscAllocateMemory(sizeof(DML_VLAN)* vlanCount);
-    memset(pVlan, 0, sizeof(DML_VLAN));
+    if ( !pVlan )
+    {
+        CcspTraceError(("%s %d - Memory allocation Failed\n", __FUNCTION__, __LINE__));
+        returnStatus = ANSC_STATUS_FAILURE;
+        return returnStatus;
+    }
+    memset(pVlan, 0, sizeof(DML_VLAN)* vlanCount);
 
     for(nIndex = 0; nIndex < vlanCount; nIndex++)
     {


### PR DESCRIPTION
RDKBDEV-3105 : Valgrind- Investigate possible memory leak in RdkVlanManager.service

Reason for change: Fix memory leaks in RdkVlanManager.
Test Procedure: Expected result - No memory leaks
Risks: None

Signed-off-by: venkatakrishna.vanga@cognizant.com